### PR TITLE
Fixes #18 Specifies encoding for findbugsXml.xml.

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/findbugs/FindBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/findbugs/FindBugsMojo.groovy
@@ -1007,13 +1007,13 @@ class FindBugsMojo extends AbstractMavenReport {
 
         def findbugsArgs = getFindbugsArgs(tempFile)
 
+        def effectiveEncoding = System.getProperty("file.encoding", "UTF-8")
+
+        if (sourceEncoding) {
+            effectiveEncoding = sourceEncoding
+        }
+
         ant.java(classname: "edu.umd.cs.findbugs.FindBugs2", inputstring: getFindbugsAuxClasspath(), fork: "${fork}", failonerror: "true", clonevm: "false", timeout: "${timeout}", maxmemory: "${maxHeap}m") {
-
-            def effectiveEncoding = System.getProperty("file.encoding", "UTF-8")
-
-            if (sourceEncoding) {
-                effectiveEncoding = sourceEncoding
-            }
 
             log.debug("File Encoding is " + effectiveEncoding)
 
@@ -1102,9 +1102,11 @@ class FindBugsMojo extends AbstractMavenReport {
                 outputFile.getParentFile().mkdirs()
                 outputFile.createNewFile()
 
-                outputFile.write "\n"
+                def writer = outputFile.newWriter(effectiveEncoding)
 
-                outputFile << xmlBuilder.bind { mkp.yield path }
+                writer.write "\n"
+
+                writer << xmlBuilder.bind { mkp.yield path }
             } else {
                 log.info("No bugs found")
             }


### PR DESCRIPTION
findbugsXml.xml in maven-findbugs-plugin-3.0.0: multibyte-characters are written in numeric character refarences (like &#xxxxxx;)
findbugsXml.xml in maven-findbugs-plugin-3.0.1: multibyte-characters are written encoded with the system file encoding.

`StreamingMarkupBuilder` looks have changed its behavior between groovy 1.8.2 and 2.4.0 (e3be0dd394fc0ecd7c65602ab61b107bc3a935e6).
This results #18, an decoding error in parsing findbugsXml.xml.

This change defines encoding for findbugsXml.xml explicitly.