### PR TITLE
Updated to stop using ArrayList instead of List for plugin parameters.

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/findbugs/FindBugsGui.groovy
+++ b/src/main/groovy/org/codehaus/mojo/findbugs/FindBugsGui.groovy
@@ -70,7 +70,7 @@ class FindBugsGui extends AbstractMojo {
      *
      */
     @Parameter( property="plugin.artifacts", required = true, readonly = true )
-    ArrayList pluginArtifacts
+    List pluginArtifacts
 
     /**
      * Effort of the bug finders. Valid values are Min, Default and Max.

--- a/src/main/groovy/org/codehaus/mojo/findbugs/FindBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/findbugs/FindBugsMojo.groovy
@@ -166,7 +166,7 @@ class FindBugsMojo extends AbstractMavenReport {
      *
      */
     @Parameter(property = "plugin.artifacts", required = true, readonly = true)
-    ArrayList pluginArtifacts
+    List pluginArtifacts
 
     /**
      * List of Remote Repositories used by the resolver

--- a/src/main/groovy/org/codehaus/mojo/findbugs/FindbugsViolationCheckMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/findbugs/FindbugsViolationCheckMojo.groovy
@@ -164,7 +164,7 @@ class FindbugsViolationCheckMojo extends AbstractMojo {
      *
      */
     @Parameter( property="plugin.artifacts", required = true, readonly = true )
-    ArrayList pluginArtifacts
+    List pluginArtifacts
 
     /**
      * The local repository, needed to download the coreplugin jar.


### PR DESCRIPTION
"Unable to parse configuration of mojo org.codehaus.mojo:findbugs-maven-plugin:3.0.2:findbugs for parameter pluginArtifacts: Cannot assign configuration entry 'pluginArtifacts' with value '${plugin.artifacts}' of type java.util.Collections.UnmodifiableRandomAccessList to property of type java.util.ArrayList"

```
Apache Maven 3.4.0-SNAPSHOT (d5ba185c1ab926b53acb0947c8a13ad74eac55e6; 2015-12-22T00:53:17+01:00)
Java version: 1.8.0_45, vendor: Oracle Corporation
Java home: /usr/local/jdk-1.8.0/jre
Default locale: en_DE, platform encoding: UTF-8
```
