### PR TITLE
Upgrade mojo-parent from 35 to 40 to remove nexus.codehaus.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.mojo</groupId>
     <artifactId>mojo-parent</artifactId>
-    <version>35</version>
+    <version>40</version>
   </parent>
 
   <groupId>org.codehaus.mojo</groupId>
@@ -97,8 +97,8 @@
   </prerequisites>
 
   <scm>
-    <connection>scm:git:git@github.com:gleclaire/findbugs-maven-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:gleclaire/findbugs-maven-plugin.git</developerConnection>
+    <connection>scm:git:https://github.com/gleclaire/findbugs-maven-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/gleclaire/findbugs-maven-plugin.git</developerConnection>
     <url>https://github.com/gleclaire/findbugs-maven-plugin</url>
   </scm>
   <issueManagement>


### PR DESCRIPTION
Upgrade mojo-parent from 35 to 40 to fix this problem I'm seeing when using findbugs-maven-plugin 3.0.4 which still has an (indirect) reference to http://nexus.codehaus.org, which is down and gone now, but used to be referenced in (parent of a parent of the parent) of mojo-parent 35:

```
[INFO] --- findbugs-maven-plugin:3.0.4:findbugs (findbugs) @ mdsal-binding-test-utils ---
Downloading: http://nexus.codehaus.org/snapshots/org/opendaylight/odlparent/findbugs/1.8.0-SNAPSHOT/maven-metadata.xml
[WARNING] Could not transfer metadata org.opendaylight.odlparent:findbugs:1.8.0-SNAPSHOT/maven-metadata.xml from/to codehaus-snapshots (http://nexus.codehaus.org/snapshots/): nexus.codehaus.org: Name or service not known
[WARNING] Failure to transfer org.opendaylight.odlparent:findbugs:1.8.0-SNAPSHOT/maven-metadata.xml from http://nexus.codehaus.org/snapshots/ was cached in the local repository, resolution will not be reattempted until the update interval of codehaus-snapshots has elapsed or updates are forced. Original error: Could not transfer metadata org.opendaylight.odlparent:findbugs:1.8.0-SNAPSHOT/maven-metadata.xml from/to codehaus-snapshots (http://nexus.codehaus.org/snapshots/): nexus.codehaus.org: Name or service not known
```

I've tested that with this change, the error above does not occur anymore in builds.

The changes to the connection & developerConnection are because the new mojo-parent appears to verify those URLs more strictly than the currently used one. (BTW: I'm not 100% sure that the developerConnection is in the right format; but that appears to be the regexp that mojo-parent 40 enforced.)