### PR TITLE
update groovy to 2.4.11 for java 9 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 
   <properties>
     <gmavenVersion>1.5</gmavenVersion>
-    <groovyVersion>2.4.7</groovyVersion>
+    <groovyVersion>2.4.11</groovyVersion>
     <antVersion>1.9.4</antVersion>
     <doxiaVersion>1.4</doxiaVersion>
     <sitePluginVersion>3.4</sitePluginVersion>


### PR DESCRIPTION
(fixes #51)

Groovy 2.4.8 is the minimum required version for java 9 compatibility.