### PR TITLE
Do not add findbugs-maven-plugin and its dependencies to auxClasspath

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/findbugs/FindBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/findbugs/FindBugsMojo.groovy
@@ -954,14 +954,6 @@ class FindBugsMojo extends AbstractMavenReport {
 
         def auxClasspath = ""
 
-        pluginArtifacts.each() { pluginArtifact ->
-            log.debug("  Adding to AuxClasspath ->" + pluginArtifact.file.toString())
-
-            auxClasspath += pluginArtifact.file.toString() + ((pluginArtifact == pluginArtifacts[pluginArtifacts.size() - 1]) ? "" : File.pathSeparator)
-        }
-
-        log.debug("  auxClasspathElements -> ${auxClasspathElements}")
-
         if (auxClasspathElements) {
 
             log.debug("  AuxClasspath Elements ->" + auxClasspathElements)


### PR DESCRIPTION
Neither the findbugs-maven-plugin nor its (transitive) dependencies are
part of the program being analyzed, so they must not be on the auxilliary
classpath.

This fixes #55.