### PR TITLE
Bring all dependencies up-to-date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>1.5.6</version>
+      <version>3.0.24</version>
     </dependency>
     <dependency>
       <groupId>org.sonatype.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <project.build.java.target>1.7</project.build.java.target>
     <projectVersion>${project.version}</projectVersion>
     <compilerPluginVersion>3.6.1</compilerPluginVersion>
-    <pluginPluginVersion>3.4</pluginPluginVersion>
+    <pluginPluginVersion>3.5</pluginPluginVersion>
     <findbugsVersion>3.0.1</findbugsVersion>
     <jxrPluginVersion>2.5</jxrPluginVersion>
     <fb-contribVersion>4.8.2</fb-contribVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-doxia-tools</artifactId>
-      <version>1.2.1</version>
+      <version>1.4</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.mojo</groupId>
     <artifactId>mojo-parent</artifactId>
-    <version>39</version>
+    <version>40</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-impl</artifactId>
-      <version>2.1</version>
+      <version>2.4</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-resources</artifactId>
-      <version>1.0-alpha-7</version>
+      <version>1.1.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <gmavenVersion>1.5</gmavenVersion>
     <groovyVersion>2.4.12</groovyVersion>
     <antVersion>1.9.9</antVersion>
-    <doxiaVersion>1.4</doxiaVersion>
+    <doxiaVersion>1.7</doxiaVersion>
     <sitePluginVersion>3.4</sitePluginVersion>
     <project.build.java.target>1.7</project.build.java.target>
     <projectVersion>${project.version}</projectVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <fb-contribVersion>4.8.2</fb-contribVersion>
     <junitVersion>4.12</junitVersion>
     <mavenSurefireVersion>2.20</mavenSurefireVersion>
-    <InfoReportsVersion>2.8</InfoReportsVersion>
+    <InfoReportsVersion>2.9</InfoReportsVersion>
     <findbugsTestDebug>false</findbugsTestDebug>
     <integrationTestSrc>${project.build.directory}/it-src-findbugs</integrationTestSrc>
     <localTestSrc>${user.dir}/FindBugs/findbugsTestCases/src</localTestSrc>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 
   <properties>
     <gmavenVersion>1.5</gmavenVersion>
-    <groovyVersion>2.4.7</groovyVersion>
+    <groovyVersion>2.4.12</groovyVersion>
     <antVersion>1.9.4</antVersion>
     <doxiaVersion>1.4</doxiaVersion>
     <sitePluginVersion>3.4</sitePluginVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.10.4</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <groovyVersion>2.4.12</groovyVersion>
     <antVersion>1.9.9</antVersion>
     <doxiaVersion>1.7</doxiaVersion>
-    <sitePluginVersion>3.4</sitePluginVersion>
+    <sitePluginVersion>3.6</sitePluginVersion>
     <project.build.java.target>1.7</project.build.java.target>
     <projectVersion>${project.version}</projectVersion>
     <compilerPluginVersion>2.3.2</compilerPluginVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -302,12 +302,12 @@
       <extension>
         <groupId>org.apache.maven.scm</groupId>
         <artifactId>maven-scm-provider-gitexe</artifactId>
-        <version>1.8.1</version>
+        <version>1.9.5</version>
       </extension>
       <extension>
         <groupId>org.apache.maven.scm</groupId>
         <artifactId>maven-scm-manager-plexus</artifactId>
-        <version>1.8.1</version>
+        <version>1.9.5</version>
       </extension>
       <extension>
         <!-- note you can download this from http://github.com/khuxtable/wagon-gitsite -->
@@ -600,7 +600,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-scm-plugin</artifactId>
-            <version>1.9.2</version>
+            <version>1.9.5</version>
             <executions>
               <execution>
                 <id>prepare-integration-test-remote-findbugs-src</id>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <sitePluginVersion>3.6</sitePluginVersion>
     <project.build.java.target>1.7</project.build.java.target>
     <projectVersion>${project.version}</projectVersion>
-    <compilerPluginVersion>2.3.2</compilerPluginVersion>
+    <compilerPluginVersion>3.6.1</compilerPluginVersion>
     <pluginPluginVersion>3.4</pluginPluginVersion>
     <findbugsVersion>3.0.1</findbugsVersion>
     <jxrPluginVersion>2.5</jxrPluginVersion>
@@ -353,7 +353,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>${compilerPluginVersion}</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.1</version>
+        <version>2.5.3</version>
         <configuration>
           <pushChanges>false</pushChanges>
           <localCheckout>true</localCheckout>

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-container-default</artifactId>
-      <version>1.0-alpha-9</version>
+      <version>1.7.1</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <groupId>org.codehaus.mojo</groupId>
     <artifactId>mojo-parent</artifactId>
     <version>39</version>
+    <relativePath />
   </parent>
 
   <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
               <dependency>
                 <groupId>com.google.code.maven-scm-provider-svnjava</groupId>
                 <artifactId>maven-scm-provider-svnjava</artifactId>
-                <version>1.11</version>
+                <version>2.1.2</version>
               </dependency>
             </dependencies>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <findbugsVersion>3.0.1</findbugsVersion>
     <jxrPluginVersion>2.5</jxrPluginVersion>
     <fb-contribVersion>4.8.2</fb-contribVersion>
-    <junitVersion>4.8.1</junitVersion>
+    <junitVersion>4.12</junitVersion>
     <mavenSurefireVersion>2.6</mavenSurefireVersion>
     <InfoReportsVersion>2.8</InfoReportsVersion>
     <findbugsTestDebug>false</findbugsTestDebug>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.0</version>
+      <version>3.5.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -460,9 +460,9 @@
         <version>${InfoReportsVersion}</version>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.googlecode.l10n-maven-plugin</groupId>
         <artifactId>l10n-maven-plugin</artifactId>
-        <version>1.0-alpha-2</version>
+        <version>1.8</version>
         <configuration>
           <locales>
             <locale>es</locale>

--- a/pom.xml
+++ b/pom.xml
@@ -513,7 +513,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.1</version>
+        <version>2.4</version>
         <reportSets>
           <reportSet>
             <reports>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <jxrPluginVersion>2.5</jxrPluginVersion>
     <fb-contribVersion>4.8.2</fb-contribVersion>
     <junitVersion>4.12</junitVersion>
-    <mavenSurefireVersion>2.6</mavenSurefireVersion>
+    <mavenSurefireVersion>2.20</mavenSurefireVersion>
     <InfoReportsVersion>2.8</InfoReportsVersion>
     <findbugsTestDebug>false</findbugsTestDebug>
     <integrationTestSrc>${project.build.directory}/it-src-findbugs</integrationTestSrc>

--- a/pom.xml
+++ b/pom.xml
@@ -537,7 +537,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-invoker-plugin</artifactId>
-            <version>1.5</version>
+            <version>3.0.0</version>
             <executions>
               <execution>
                 <id>prepare-integration-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
   <properties>
     <gmavenVersion>1.5</gmavenVersion>
     <groovyVersion>2.4.12</groovyVersion>
-    <antVersion>1.9.4</antVersion>
+    <antVersion>1.9.9</antVersion>
     <doxiaVersion>1.4</doxiaVersion>
     <sitePluginVersion>3.4</sitePluginVersion>
     <project.build.java.target>1.7</project.build.java.target>

--- a/src/site/resources/examples/findbugs.html
+++ b/src/site/resources/examples/findbugs.html
@@ -30,7 +30,7 @@
         <span id="publishDate">Last Published: 2015-09-21</span>
                   &nbsp;| <span id="projectVersion">Version: testing</span>
                       </div>
-            <div class="xright">                    <a href="${project.url}" title="basic-1">basic-1</a>
+            <div class="xright">                    <a href="${this.project.url}" title="basic-1">basic-1</a>
               
                     
       </div>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,6 +1,6 @@
 
 <project xmlns="http://maven.apache.org/DECORATION/1.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/DECORATION/1.7.0 http://maven.apache.org/xsd/decoration-1.7.0.xsd"
     name="FindBugs Maven Plugin">
 
 
@@ -24,7 +24,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.3.1</version>
+    <version>1.6</version>
   </skin>
 
   <custom>


### PR DESCRIPTION
Not all of these actually are updated due to management in mojo parent as reported by versions plugin on site page.  A second pass will be necessary to properly override if that is the intent but most likely these are all properly being used and the plugin is catching the differences in configuration.