### PR TITLE
config: fix link for gleclaire.github.io/findbugs-maven-plugin to be …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <name>FindBugs Maven Plugin</name>
   <description>This Plug-In generates reports based on the FindBugs Library</description>
-  <url>http://gleclaire.github.io/findbugs-maven-plugin/</url>
+  <url>https://gleclaire.github.io/findbugs-maven-plugin/</url>
   <inceptionYear>2005</inceptionYear>
   <licenses>
     <license>


### PR DESCRIPTION
…https instead of http

checkstyle project use plugin in maven site generation.
we verify links by linkcheck plugin to be valid.
Build failure in checkstyle project - https://app.codeship.com/projects/124310/builds/27342727?pipeline=71f10cb9-a5c7-4e8b-b604-92f50e8e048f
```
<td><i><a class="externalLink" href="http://gleclaire.github.io/findbugs-maven-plugin/">http://gleclaire.github.io/findbugs-maven-plugin/</a>: 301 Moved Permanently</i></td></tr></table></td></tr>
```