### PR TITLE
[pom] Upgrade remote source to use github instead of legacy svn repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Skip tests
 ```
 mvn -DskipTests=true clean install
 ```
-Run tests on findbugs test source code that is local instead of from FindBugs SVN repository
+Run tests on findbugs test source code that is local instead of from FindBugs github repository
 ```
 mvn -DtestSrc=local -DlocalTestSrc=/opt/findBugs/findbugsTestCases/src -Prun-its clean install
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -129,12 +129,12 @@
     <junitVersion>4.12</junitVersion>
     <mavenSurefireVersion>2.20</mavenSurefireVersion>
     <InfoReportsVersion>2.9</InfoReportsVersion>
+
     <findbugsTestDebug>false</findbugsTestDebug>
     <integrationTestSrc>${project.build.directory}/it-src-findbugs</integrationTestSrc>
-    <localTestSrc>${user.dir}/FindBugs/findbugsTestCases/src</localTestSrc>
-    <remoteTestSrc>scm:svn:http://findbugs.googlecode.com/svn/branches/1.3.9/findbugsTestCases/src</remoteTestSrc>
-    <!-- <remoteTestSrc>scm:svn:http://findbugs.googlecode.com/svn/trunk/findbugsTestCases/src/java/</remoteTestSrc> -->
-    <includesTestSrcPattern>**/A*.java, **/Use*.java</includesTestSrcPattern>
+    <localTestSrc>${user.dir}/FindBugs</localTestSrc>
+    <remoteTestSrc>scm:git:https://github.com/findbugsproject/findbugs/</remoteTestSrc>
+    <includesTestSrcPattern>**findbugsTestCases/src/java/A*.java, **findbugsTestCases/src/java/Use*.java</includesTestSrcPattern>
     <testSrc>remote</testSrc>
 
     <pmd.skip>true</pmd.skip>
@@ -583,8 +583,9 @@
         </plugins>
       </build>
     </profile>
+
     <profile>
-      <id>find-it-src-export</id>
+      <id>find-it-src-checkout</id>
       <activation>
         <!-- <file> -->
         <!-- <missing>${integrationTestSrc}/A.java</missing> -->
@@ -605,13 +606,13 @@
                 <id>prepare-integration-test-remote-findbugs-src</id>
                 <phase>pre-integration-test</phase>
                 <goals>
-                  <goal>export</goal>
+                  <goal>checkout</goal>
                 </goals>
                 <configuration>
                   <connectionUrl>${remoteTestSrc}</connectionUrl>
                   <exportDirectory>${integrationTestSrc}</exportDirectory>
                   <providerImplementations>
-                    <svn>javasvn</svn>
+                    <git>jgit</git>
                   </providerImplementations>
                   <includes>${includesTestSrcPattern}</includes>
                 </configuration>
@@ -619,9 +620,9 @@
             </executions>
             <dependencies>
               <dependency>
-                <groupId>com.google.code.maven-scm-provider-svnjava</groupId>
-                <artifactId>maven-scm-provider-svnjava</artifactId>
-                <version>2.1.2</version>
+                <groupId>org.apache.maven.scm</groupId>
+                <artifactId>maven-scm-provider-jgit</artifactId>
+                <version>1.9.5</version>
               </dependency>
             </dependencies>
           </plugin>


### PR DESCRIPTION
Note: Original remote no longer exists so this is hard to test.  Any advice on how to test would be great.  It is pulling down what is expected but in different structure as git pulls everything on clone not directory portions.  So the local reference is changed to be the same.  Beyond that I'm not clear on how this is used and it's otherwise been broken for a very long time given googlecode went out of date a pretty long time ago.