### PR TITLE
[ci] Disable cobertura as there is no test code across main library a…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,15 @@
             <skipDeploy>false</skipDeploy>
           </configuration>
         </plugin>
+
+        <!--  Disable cobertura from parent -->
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>cobertura-maven-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -432,28 +441,6 @@
           <skipTests>true</skipTests>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <configuration>
-          <instrumentation>
-            <ignores>
-              <ignore>org.codehaus.mojo.findbugs.*</ignore>
-            </ignores>
-            <excludes>
-              <exclude>org/codehaus/mojo/findbugs/**/*.class</exclude>
-            </excludes>
-          </instrumentation>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
@@ -559,6 +546,14 @@
             </reports>
           </reportSet>
         </reportSets>
+      </plugin>
+      <!--  Disable cobertura from parent -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
…nd it was already ignored

This is primary attempt in getting this running on java 9 on travis.  It will get farther which this but then invokers fail but I think this in general is right idea since there is no direct unit code just the intergration tests.